### PR TITLE
feat: add support for using environment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 This plugin will fetch output values from another environment and insert them as terraform and/or environment variables.
 
-
 Similar to self hosted agent secrets, use this notation in the value of the terraform input value:
 
 `${env0:<environment id>:<output name>}`
+`${env0:<environment name>:<output name>}` (see note below about Environment Names restrictions)
 
 ## Requirements
 
 The plugin uses the env0 API to fetch the output values from another environment. Therefore, we need to declare the ENV0_API_KEY and ENV0_API_SECRET environment variables in the environment or project with access to the source environments. You can either use [Organization API Keys](https://docs.env0.com/docs/api-keys) or [Personal API Keys](https://docs.env0.com/reference/authentication#creating-a-personal-api-key)
 * `ENV0_API_KEY`
 * `ENV0_API_SECRET` 
+
+## Environment Name Restrictions
+
+* Environment Names must be unique, otherwise, the script just uses the "first" matching environment name.
+* Environment Names must not include spaces " " or slashes `/`. Ideally, your environment only contains alphanumeric characters and dashes `-`. **
 
 ## Inputs
 
@@ -45,3 +50,6 @@ deploy:
 ## Further Reading
 
 This plugin takes advantage of [Terraform variable precendence](https://developer.hashicorp.com/terraform/language/values/variables#variable-definition-precedence) and *.auto.tfvars. 
+
+
+** If you must know why, it's because this script is written in Bash, and I'm taking advantage of Bash arrays which doesn't process spaces well, and also I'm saving the outputs to the filesystem which gets confused with slashes.

--- a/importVariables.sh
+++ b/importVariables.sh
@@ -30,15 +30,15 @@ if [[ -e env0.auto.tfvars.json ]]; then
 
   # for each variable in env0.auto.tfvars.json 
   for ((i = 0; i < LENGTH; i++)); do
-    [[ $DEBUG ]] && echo "${i}: ${VALUES[i]}"
+    #[[ $DEBUG ]] && echo "${i}: ${VALUES[i]}"
     if [[ ${VALUES[i]} =~ ^\"\$\{env0:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:.*\}\"$ ]]; then
-      echo "${i}: ${KEYS[i]}:${VALUES[i]}"
+      #[[ $DEBUG ]] && echo "${i}: ${KEYS[i]}:${VALUES[i]}"
       # split the string across ':'
       SPLIT_VALUES=($(echo ${VALUES[i]} | tr ":" "\n"))
       SOURCE_ENV0_ENVIRONMENT_ID=${SPLIT_VALUES[1]}
       len=$((${#SPLIT_VALUES[2]}-2))
       SOURCE_OUTPUT_NAME=${SPLIT_VALUES[2]:0:$len}
-      echo "fetch value for ${KEYS[i]}:$SOURCE_OUTPUT_NAME from ${SOURCE_ENV0_ENVIRONMENT_ID}"
+      [[ $DEBUG ]] && echo "fetch value for ${KEYS[i]}:$SOURCE_OUTPUT_NAME from ${SOURCE_ENV0_ENVIRONMENT_ID}"
 
       # fetch logs from environment
       if [[ ! -e $SOURCE_ENV0_ENVIRONMENT_ID.json ]]; then
@@ -55,7 +55,7 @@ if [[ -e env0.auto.tfvars.json ]]; then
       echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE" >> $TFVAR_FILENAME
       
     elif [[ ${VALUES[i]} =~ ^\"\$\{env0:.*:.*\}\"$ ]]; then
-      echo ${KEYS[i]}:${VALUES[i]}
+      #[[ $DEBUG ]] && echo ${KEYS[i]}:${VALUES[i]}
       SPLIT_VALUES=($(echo ${VALUES[i]} | tr ":" "\n")) 
       SOURCE_ENV0_ENVIRONMENT_NAME=${SPLIT_VALUES[1]}
       len=$((${#SPLIT_VALUES[2]}-2))
@@ -70,14 +70,14 @@ if [[ -e env0.auto.tfvars.json ]]; then
         -o $SOURCE_ENV0_ENVIRONMENT_NAME.json
       fi
 
-      SOURCE_OUTPUT_VALUE=$(jq "[0].latestDeploymentLog.output.$SOURCE_OUTPUT_NAME.value" $SOURCE_ENV0_ENVIRONMENT_NAME.json)
+      SOURCE_OUTPUT_VALUE=$(jq ".[0].latestDeploymentLog.output.$SOURCE_OUTPUT_NAME.value" $SOURCE_ENV0_ENVIRONMENT_NAME.json)
       #echo $SOURCE_OUTPUT_VALUE
       echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE" >> $TFVAR_FILENAME
     fi
   done
 
   # show updated values
-  if [[ -n DEBUG || -e $TFVAR_$FILENAME ]]; then cat $TFVAR_FILENAME; fi
+  [[ -n $DEBUG || -e $TFVAR_$FILENAME ]] && cat $TFVAR_FILENAME
 fi
 
 ### Repeat process for Environment Variables
@@ -130,7 +130,7 @@ for ((i = 0; i < LENGTH; i++)); do
       -o $SOURCE_ENV0_ENVIRONMENT_NAME.json
     fi
 
-    SOURCE_OUTPUT_VALUE=$(jq "[0].latestDeploymentLog.output.$SOURCE_OUTPUT_NAME.value" $SOURCE_ENV0_ENVIRONMENT_NAME.json)
+    SOURCE_OUTPUT_VALUE=$(jq ".[0].latestDeploymentLog.output.$SOURCE_OUTPUT_NAME.value" $SOURCE_ENV0_ENVIRONMENT_NAME.json)
     #echo $SOURCE_OUTPUT_VALUE
     echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE"
     echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE" >> $ENV0_ENV 

--- a/importVariables.sh
+++ b/importVariables.sh
@@ -13,13 +13,13 @@
 # lexical order, so last file wins!
 if [[ -e env0.auto.tfvars.json ]]; then
 
-  [[ $DEBUG ]] && cat env0.auto.tfvars.json
+  [[ -n $DEBUG ]] && cat env0.auto.tfvars.json
 
   KEYS=($(jq -rc 'keys | .[]' env0.auto.tfvars.json))
   VALUES=($(jq -c '.[]' env0.auto.tfvars.json))
   LENGTH=$(jq 'length' env0.auto.tfvars.json)
 
-  [[ $DEBUG ]] && echo ${VALUES[@]}
+  [[ -n $DEBUG ]] && echo ${VALUES[@]}
 
   TFVAR_FILENAME=env1.auto.tfvars
   if [[ -e $TFVAR_FILENAME ]]; then

--- a/importVariables.sh
+++ b/importVariables.sh
@@ -20,6 +20,8 @@ if [[ -e env0.auto.tfvars.json ]]; then
   LENGTH=$(jq 'length' env0.auto.tfvars.json)
 
   if [[ -n $DEBUG ]]; then echo ${VALUES[@]}; fi
+  
+  echo ${VALUES[@]}
 
   TFVAR_FILENAME=env1.auto.tfvars
   if [[ -e $TFVAR_FILENAME ]]; then
@@ -27,8 +29,6 @@ if [[ -e env0.auto.tfvars.json ]]; then
   else 
     touch $TFVAR_FILENAME
   fi 
-
-
 
   # for each variable in env0.auto.tfvars.json 
   for ((i = 0; i < LENGTH; i++)); do

--- a/importVariables.sh
+++ b/importVariables.sh
@@ -13,13 +13,13 @@
 # lexical order, so last file wins!
 if [[ -e env0.auto.tfvars.json ]]; then
 
-  [[ -n $DEBUG ]] && cat env0.auto.tfvars.json
+  if [[ -n $DEBUG ]]; then cat env0.auto.tfvars.json; fi
 
   KEYS=($(jq -rc 'keys | .[]' env0.auto.tfvars.json))
   VALUES=($(jq -c '.[]' env0.auto.tfvars.json))
   LENGTH=$(jq 'length' env0.auto.tfvars.json)
 
-  [[ -n $DEBUG ]] && echo ${VALUES[@]}
+  if [[ -n $DEBUG ]]; then echo ${VALUES[@]}; fi
 
   TFVAR_FILENAME=env1.auto.tfvars
   if [[ -e $TFVAR_FILENAME ]]; then

--- a/importVariables.sh
+++ b/importVariables.sh
@@ -92,7 +92,7 @@ for ((i = 0; i < LENGTH; i++)); do
     # unset ${KEYS[i]}
     echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE" >> $ENV0_ENV
   # check for ${env0:environmentname:output}
-  else if [[ ${VALUES[i]} =~ ^\"\$\{env0:[\S ]*:\S*\}\"$ ]]; then
+  elif [[ ${VALUES[i]} =~ ^\"\$\{env0:[\S ]*:\S*\}\"$ ]]; then
     echo ${KEYS[i]}:${VALUES[i]}
     SPLIT_VALUES=($(echo ${VALUES[i]} | tr ":" "\n")) 
     SOURCE_ENV0_ENVIRONMENT_NAME=${SPLIT_VALUES[1]}

--- a/importVariables.sh
+++ b/importVariables.sh
@@ -13,9 +13,13 @@
 # lexical order, so last file wins!
 if [[ -e env0.auto.tfvars.json ]]; then
 
+  [[ $DEBUG ]] && cat env0.auto.tfvars.json
+
   KEYS=($(jq -rc 'keys | .[]' env0.auto.tfvars.json))
   VALUES=($(jq -c '.[]' env0.auto.tfvars.json))
   LENGTH=$(jq 'length' env0.auto.tfvars.json)
+
+  [[ $DEBUG ]] && echo ${VALUES[@]}
 
   TFVAR_FILENAME=env1.auto.tfvars
   if [[ -e $TFVAR_FILENAME ]]; then
@@ -23,6 +27,8 @@ if [[ -e env0.auto.tfvars.json ]]; then
   else 
     touch $TFVAR_FILENAME
   fi 
+
+
 
   # for each variable in env0.auto.tfvars.json 
   for ((i = 0; i < LENGTH; i++)); do
@@ -107,7 +113,7 @@ for ((i = 0; i < LENGTH; i++)); do
     #echo $SOURCE_OUTPUT_VALUE
     echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE"
     echo "${KEYS[i]}=$SOURCE_OUTPUT_VALUE" >> $ENV0_ENV
-    
+
   # check for ${env0:environmentname:output}
   elif [[ ${VALUES[i]} =~ ^\"\$\{env0:[\S ]*:\S*\}\"$ ]]; then
     echo ${KEYS[i]}:${VALUES[i]}

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -7,3 +7,4 @@ deploy:
         - name: Import Variables
           run: |
             ../importVariables.sh
+            cat env1.auto.tfvars

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -6,5 +6,6 @@ deploy:
       after:
         - name: Import Variables
           run: |
-            cat env0.auto.tfvars
+            cat env0.auto.tfvars.json
+            export DEBUG=1
             ../importVariables.sh

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+deploy:
+  steps:
+    setupVariables:
+      after:
+        - name: Import Variables
+          run: |
+            ../importVariables.sh

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -6,5 +6,5 @@ deploy:
       after:
         - name: Import Variables
           run: |
+            cat env0.auto.tfvars
             ../importVariables.sh
-            cat env1.auto.tfvars

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -8,3 +8,9 @@ deploy:
           run: |
             export DEBUG=1
             ../importVariables.sh
+    terraformOutput:
+      after:
+        - name: Test Outputs
+          run: |
+            echo $ENV0_ENV
+            cat env1.auto.tfvars

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -12,5 +12,5 @@ deploy:
       after:
         - name: Test Outputs
           run: |
-            echo $ENV0_ENV
+            export | grep -i "env"
             cat env1.auto.tfvars

--- a/test/env0.yaml
+++ b/test/env0.yaml
@@ -6,6 +6,5 @@ deploy:
       after:
         - name: Import Variables
           run: |
-            cat env0.auto.tfvars.json
             export DEBUG=1
             ../importVariables.sh

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,11 +2,11 @@ resource "null_resource" "null" {
 }
 
 output "test_envid" {
-  value = var.test_input
+  value = var.test_envid
 }
 
 output "test_envname" {
-  value = var.test_input
+  value = var.test_envname
 }
 
 variable "test_envid" {

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,18 @@
+resource "null_resource" "null" {
+}
+
+output "test_envid" {
+  value = var.test_input
+}
+
+output "test_envname" {
+  value = var.test_input
+}
+
+variable "test_envid" {
+  type = string
+}
+
+variable "test_envname" {
+  type = string
+}

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -1,3 +1,3 @@
 output "time" {
-  value = > timestamp()
+  value = timestamp()
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -1,0 +1,3 @@
+output "time" {
+  value = > timestamp()
+}

--- a/test/test.auto.tfvars
+++ b/test/test.auto.tfvars
@@ -1,1 +1,2 @@
-test_envid=${env0:
+test_envid = "$${env0:1dd5d373-cd56-442e-9006-01a3d6f72ced:time}"
+test_envname = "$${env0:env0-import-variable-plugin test:time}"

--- a/test/test.auto.tfvars
+++ b/test/test.auto.tfvars
@@ -1,0 +1,1 @@
+test_envid=${env0:

--- a/test/test.auto.tfvars
+++ b/test/test.auto.tfvars
@@ -1,2 +1,0 @@
-test_envid = "$${env0:1dd5d373-cd56-442e-9006-01a3d6f72ced:time}"
-test_envname = "$${env0:env0-import-variable-plugin test:time}"


### PR DESCRIPTION
add ability to use this format: `${env0:<environment name>:<output key>}` 
restrictions: environment names can't have spaces or slashes. 