### PR TITLE
add -f in the mv command

### DIFF
--- a/env0.plugin.yaml
+++ b/env0.plugin.yaml
@@ -8,8 +8,8 @@ run:
     cd env0-import-variable-plugin
     #cat main.go
     go build -o ./bin/import-variable-plugin main.go 
-    mv ./bin/import-variable-plugin /opt
-    mv ./importVariables.sh /opt/importEnvVariables
+    mv -f ./bin/import-variable-plugin /opt
+    mv -f ./importVariables.sh /opt/importEnvVariables
     cd $ENV0_TEMPLATE_DIR
     import-variable-plugin
     importEnvVariables


### PR DESCRIPTION
When I tried to destroy the environment, the script was unable to move some directories because they already existed. The `-f` flag will force the move even if the folder exists.

![image](https://github.com/env0/env0-import-variable-plugin/assets/11510919/d093fd38-c9f2-4d9e-842c-1589bfa7a9f4)


