### PR TITLE
fix: read values in line by line instead of relying on IFS

### DIFF
--- a/importVariables.sh
+++ b/importVariables.sh
@@ -20,7 +20,7 @@ if [[ ! -e "env0.env-vars.json" ]]; then
 fi
 
 KEYS=($(jq -rc 'keys_unsorted | .[]' env0.env-vars.json))
-VALUES=($(jq -c '.[]' env0.env-vars.json))
+mapfile -t VALUES < <(jq -c '.[]' env0.env-vars.json)
 LENGTH=$(jq 'length' env0.env-vars.json)
 
 UUID_REGEX='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'


### PR DESCRIPTION
Fixes an issue with reading in values from `env0.env-vars.json` where if any of the values contained spaces they would be treated as separators when bash parses through them due to IFS. This causes issues when iterating through key value pairs if `VALUES` erroneously ends up holding extra values.

For example, given this `env0.env-vars.json`:
```json
{
  "ENV0_K8S_EKS_AUTH_CLUSTER_NAME": "my-cluster",
  "ENV0_K8S_EKS_AUTH_CLUSTER_REGION": "us-west-2",
  "ENV0_AWS_ROLE_DURATION": "7200",
  "ENV0_AWS_ROLE_ARN": "my-role",
  "ENV0_AWS_ROLE_EXTERNAL_ID": "my-role-id",
  "ENV0_CREDENTIAL_TYPES": "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT, K8S_EKS_AUTH",
  "ARGO_CONFIG_SUBDIR_OVERRIDE": "",
  "AWS_ACCOUNT_NAME": "my-aws-account",
  "BOOTSTRAP_TARGET_BRANCH": "v1.19.5",
  "CREATE_EXTERNAL_INGRESS": "false",
  "EKS_CERT_MANAGER_ROLE_ARN": "${env0-workflow:cluster:eks_cert_manager_irsa_arn}",
  "EKS_CLUSTER_NAME": "${env0-workflow:cluster:cluster_name}",
  "EKS_EXTERNAL_DNS_ROLE_ARN": "${env0-workflow:cluster:external_dns_irsa_arn}",
  "EKS_EXTERNAL_SECRETS_ROLE_ARN": "${env0-workflow:cluster:eks_argocd_cluster_setup_irsa_arn}",
  "ENV0_API_KEY": "my-api-key",
  "ENV0_API_SECRET": "my-api-secret",
  "MANAGE_PROJECT_CLUSTER_CREDENTIALS": "false",
  "TARGET_EKS_CLUSTER": "my-cluster"
}
```

If these values are read in with `VALUES=($(jq -c '.[]' env0.env-vars.json))` this will produce the following results when iterated through with:

```bash
# write to ENV0_ENV
# for each variable in env0.env-vars.json 
for ((i = 0; i < LENGTH; i++)); do
  echo ${KEYS[i]}:${VALUES[i]}
```

```
ENV0_K8S_EKS_AUTH_CLUSTER_NAME:"sd-prod-00-core-00-cluster"
ENV0_K8S_EKS_AUTH_CLUSTER_REGION:"us-west-2"
ENV0_AWS_ROLE_DURATION:"7200"
ENV0_AWS_ROLE_ARN:"arn:aws:iam::286696986118:role/Env0-AssumeRole"
ENV0_AWS_ROLE_EXTERNAL_ID:"e87101ef-2595-4bf3-a473-d567fc8fcdba"
ENV0_CREDENTIAL_TYPES:"AWS_ASSUMED_ROLE_FOR_DEPLOYMENT,
ARGO_CONFIG_SUBDIR_OVERRIDE:K8S_EKS_AUTH"
AWS_ACCOUNT_NAME:""
BOOTSTRAP_TARGET_BRANCH:"sd-prod-00"
CREATE_EXTERNAL_INGRESS:"v1.19.5"
EKS_CERT_MANAGER_ROLE_ARN:"false"
EKS_CLUSTER_NAME:"${env0-workflow:cluster:eks_cert_manager_irsa_arn}"
EKS_EXTERNAL_DNS_ROLE_ARN:"${env0-workflow:cluster:cluster_name}"
EKS_EXTERNAL_SECRETS_ROLE_ARN:"${env0-workflow:cluster:external_dns_irsa_arn}"
ENV0_API_KEY:"${env0-workflow:cluster:eks_argocd_cluster_setup_irsa_arn}"
ENV0_API_SECRET:"6i9punk1qu2tckkh"
MANAGE_PROJECT_CLUSTER_CREDENTIALS:"*************"
TARGET_EKS_CLUSTER:"false"
```

As you can see everything after `ENV0_CREDENTIAL_TYPES` gets shifted incorrectly due to the space in the value, which creates an extra element in `VALUES`.

If I instead read in values line by line with `mapvalues` (and not use IFS) I get the expected result of:
```bash
# write to ENV0_ENV
# for each variable in env0.env-vars.json 
for ((i = 0; i < LENGTH; i++)); do
  echo ${KEYS[i]}:${VALUES[i]}
```

```
ENV0_K8S_EKS_AUTH_CLUSTER_NAME:"my-cluster"
ENV0_K8S_EKS_AUTH_CLUSTER_REGION:"us-west-2"
ENV0_AWS_ROLE_DURATION:"7200"
ENV0_AWS_ROLE_ARN:"my-role"
ENV0_AWS_ROLE_EXTERNAL_ID:"my-role-id"
ENV0_CREDENTIAL_TYPES:"AWS_ASSUMED_ROLE_FOR_DEPLOYMENT, K8S_EKS_AUTH"
ARGO_CONFIG_SUBDIR_OVERRIDE:""
AWS_ACCOUNT_NAME:"my-aws-account"
BOOTSTRAP_TARGET_BRANCH:"v1.19.5"
CREATE_EXTERNAL_INGRESS:"false"
EKS_CERT_MANAGER_ROLE_ARN:"${env0-workflow:cluster:eks_cert_manager_irsa_arn}"
EKS_CLUSTER_NAME:"${env0-workflow:cluster:cluster_name}"
EKS_EXTERNAL_DNS_ROLE_ARN:"${env0-workflow:cluster:external_dns_irsa_arn}"
EKS_EXTERNAL_SECRETS_ROLE_ARN:"${env0-workflow:cluster:eks_argocd_cluster_setup_irsa_arn}"
ENV0_API_KEY:"my-api-key"
ENV0_API_SECRET:"my-api-secret"
MANAGE_PROJECT_CLUSTER_CREDENTIALS:"false"
TARGET_EKS_CLUSTER:"my-cluster"
```